### PR TITLE
update channel name to match voxelmap's listener

### DIFF
--- a/src/main/kotlin/constants.kt
+++ b/src/main/kotlin/constants.kt
@@ -1,3 +1,3 @@
 package info.journeymap.bukkit
 
-val WORLD_ID_CHANNEL = "info:world_info"
+val WORLD_ID_CHANNEL = "worldinfo:world_info"


### PR DESCRIPTION
As of journeymap 5.7.1 beta 4, the channel name will be `worldinfo:world_id` so that voxelmap and jourenymap can use the same worldId