### PR TITLE
Adds configuration to override world IDs + migrations from old plugin

### DIFF
--- a/src/main/kotlin/info/journeymap/bukkit/Configuration.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/Configuration.kt
@@ -36,12 +36,14 @@ public class Configuration(private val plugin: JourneyMapBukkit) {
 
         // check for explicit WorldID
         val explicitWorldId = conf.getString("WorldID")
+
         if (explicitWorldId !== null) {
             return explicitWorldId
         }
 
         // check for id_from declaration
         val idFrom = conf.getString("id_from")
+
         if (idFrom !== null) {
             return try {
                 getWorldId(idFrom)
@@ -66,6 +68,7 @@ public class Configuration(private val plugin: JourneyMapBukkit) {
             }
 
             val idFrom = getWorlds().getString("$worldName.id_from")
+
             if (idFrom !== null) {
                 try {
                     getWorldId(idFrom)
@@ -87,6 +90,7 @@ public class Configuration(private val plugin: JourneyMapBukkit) {
 
         val legacyDataFolder = plugin.dataFolder.parentFile.resolve("JourneyMapServer")
         val files = legacyDataFolder.listFiles { _, name -> name.endsWith(".cfg") }
+
         if (files === null) {
             // legacy directory does not exist
             plugin.config.set(MIGRATION_KEY, true)

--- a/src/main/kotlin/info/journeymap/bukkit/Configuration.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/Configuration.kt
@@ -1,0 +1,126 @@
+package info.journeymap.bukkit
+
+import org.bukkit.Bukkit
+import org.bukkit.configuration.MemoryConfiguration
+import org.bukkit.configuration.file.YamlConfiguration
+import java.time.LocalDateTime
+
+private const val WORLDS_KEY = "worlds"
+private const val MIGRATION_KEY = "legacy_configuration_migrated"
+
+public class Configuration(private val plugin: JourneyMapBukkit) {
+
+    public fun init() {
+        plugin.saveDefaultConfig()
+        this.migrateLegacyConfiguration()
+        this.validateConfig()
+
+        if (doVerboseLogging()) {
+            for (world in Bukkit.getWorlds()) {
+                plugin.logger.info("World '${world.name}' uses ID '${resolveWorldId(world.name)}'.")
+            }
+        }
+    }
+
+    public fun resolveWorldId(worldName: String): String? {
+        val conf = getWorlds().getConfigurationSection(worldName)
+        // send primary by default
+        if (conf === null) {
+            return getPrimaryWorldId()
+        }
+
+        // check if sending disabled
+        if (!conf.getBoolean("UseWorldID", true)) {
+            return null
+        }
+
+        // check for explicit WorldID
+        val explicitWorldId = conf.getString("WorldID")
+        if (explicitWorldId !== null) {
+            return explicitWorldId
+        }
+
+        // check for id_from declaration
+        val idFrom = conf.getString("id_from")
+        if (idFrom !== null) {
+            return try {
+                getWorldId(idFrom)
+            } catch (e: WorldNotFoundException) {
+                plugin.logger.severe("Cannot get WorldID for '$worldName': World '${e.worldName}' does not exist.")
+                null
+            }
+        }
+
+        // world is in config but with no relevant configuration
+        return getPrimaryWorldId()
+    }
+
+    public fun doVerboseLogging(): Boolean = plugin.config.getBoolean("verbose_logging", true)
+
+    private fun validateConfig() {
+        for (worldName in getWorlds().getKeys(false)) {
+            try {
+                getWorld(worldName)
+            } catch (e: WorldNotFoundException) {
+                plugin.logger.warning("World '$worldName' is specified in configuration but does not exist.")
+            }
+
+            val idFrom = getWorlds().getString("$worldName.id_from")
+            if (idFrom !== null) {
+                try {
+                    getWorldId(idFrom)
+                } catch (e: WorldNotFoundException) {
+                    plugin.logger.severe(
+                        "World '$worldName' specifies '$idFrom' for getting its world ID but that world does not exist."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun getWorlds() = plugin.config.getConfigurationSection(WORLDS_KEY) ?: MemoryConfiguration()
+
+    private fun migrateLegacyConfiguration() {
+        if (plugin.config.getBoolean(MIGRATION_KEY, false)) {
+            return
+        }
+
+        val legacyDataFolder = plugin.dataFolder.parentFile.resolve("JourneyMapServer")
+        val files = legacyDataFolder.listFiles { _, name -> name.endsWith(".cfg") }
+        if (files === null) {
+            // legacy directory does not exist
+            plugin.config.set(MIGRATION_KEY, true)
+            plugin.saveConfig()
+            return
+        }
+
+        plugin.logger.info("Migrating legacy JourneyMapServer configuration...")
+
+        val worldsConfig = getWorlds()
+        for (file in files) {
+            val worldName = file.nameWithoutExtension
+            // Yaml is a superset of JSON, so the original JSON configuration can be just read
+            val conf = YamlConfiguration.loadConfiguration(file.reader(Charsets.UTF_8))
+
+            // remove config version but keep even values we don't necessarily support yet
+            conf.set("ConfigVersion", null)
+
+            if (worldsConfig.get(worldName) !== null) {
+                plugin.logger.warning(
+                    "Overwriting existing world configuration for '$worldName' with contents of '${file.path}'."
+                )
+            }
+
+            worldsConfig.set(worldName, conf)
+
+            val comments = ArrayList<String>()
+            comments.add("Migrated from '${legacyDataFolder.resolve(worldName)}' on ${LocalDateTime.now()}")
+            worldsConfig.setComments(worldName, comments)
+        }
+
+        plugin.config.set(WORLDS_KEY, worldsConfig)
+        plugin.config.set(MIGRATION_KEY, true)
+        plugin.saveConfig()
+        plugin.logger.info("Migration finished. You may now remove old configuration folder '$legacyDataFolder'.")
+    }
+}

--- a/src/main/kotlin/info/journeymap/bukkit/EventHandler.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/EventHandler.kt
@@ -1,6 +1,7 @@
 package info.journeymap.bukkit
 
 import org.bukkit.Bukkit.getServer
+import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
@@ -9,16 +10,17 @@ import org.bukkit.event.player.PlayerJoinEvent
 
 public class EventHandler(private val plugin: JourneyMapBukkit) : Listener {
     @EventHandler(priority = EventPriority.MONITOR)
-    public fun onJoin(event: PlayerJoinEvent) {
-        getServer().scheduler.callSyncMethod(this.plugin) {
-            this.plugin.packetHandler.sendWorldId(getPrimaryWorldId(), event.player)
-        }
-    }
+    public fun onJoin(event: PlayerJoinEvent): Unit = sendWorldId(event.player)
 
     @EventHandler(priority = EventPriority.MONITOR)
-    public fun onWorldChange(event: PlayerChangedWorldEvent) {
+    public fun onWorldChange(event: PlayerChangedWorldEvent): Unit = sendWorldId(event.player)
+
+    private fun sendWorldId(player: Player) {
         getServer().scheduler.callSyncMethod(this.plugin) {
-            this.plugin.packetHandler.sendWorldId(getPrimaryWorldId(), event.player)
+            val worldID = plugin.configuration.resolveWorldId(player.world.name)
+            if (worldID !== null) {
+                this.plugin.packetHandler.sendWorldId(worldID, player)
+            }
         }
     }
 }

--- a/src/main/kotlin/info/journeymap/bukkit/EventHandler.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/EventHandler.kt
@@ -18,6 +18,7 @@ public class EventHandler(private val plugin: JourneyMapBukkit) : Listener {
     private fun sendWorldId(player: Player) {
         getServer().scheduler.callSyncMethod(this.plugin) {
             val worldID = plugin.configuration.resolveWorldId(player.world.name)
+
             if (worldID !== null) {
                 this.plugin.packetHandler.sendWorldId(worldID, player)
             }

--- a/src/main/kotlin/info/journeymap/bukkit/JourneyMapBukkit.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/JourneyMapBukkit.kt
@@ -3,11 +3,15 @@ package info.journeymap.bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
 public class JourneyMapBukkit : JavaPlugin() {
+    internal lateinit var configuration: Configuration
     internal lateinit var packetHandler: PacketHandler
     internal lateinit var eventHandler: EventHandler
 
     override fun onEnable() {
         super.onEnable()
+
+        configuration = Configuration(this)
+        configuration.init()
 
         this.packetHandler = PacketHandler(this)
         this.eventHandler = EventHandler(this)

--- a/src/main/kotlin/info/journeymap/bukkit/PacketHandler.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/PacketHandler.kt
@@ -17,18 +17,17 @@ public class PacketHandler(private val plugin: JourneyMapBukkit) : PluginMessage
 
     override fun onPluginMessageReceived(channel: String, player: Player, message: ByteArray) {
         if (channel.lowercase() == WORLD_ID_CHANNEL) {
-            this.sendWorldId(getPrimaryWorldId(), player)
-        }
-    }
-
-    public fun broadcastWorldId(worldID: String) {
-        for (player: Player in getServer().onlinePlayers) {
-            this.sendWorldId(worldID, player)
+            val worldID = plugin.configuration.resolveWorldId(player.world.name)
+            if (worldID !== null) {
+                this.sendWorldId(worldID, player)
+            }
         }
     }
 
     public fun sendWorldId(worldID: String, player: Player) {
-        this.plugin.logger.info("Sending WorldId " + worldID + " to " + player.name)
+        if (plugin.configuration.doVerboseLogging()) {
+            this.plugin.logger.info("Sending WorldId '$worldID' to '${player.name}'")
+        }
 
         try {
             this.sendPacket(player, 0.toByte(), worldID.toByteArray(), WORLD_ID_CHANNEL)

--- a/src/main/kotlin/info/journeymap/bukkit/PacketHandler.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/PacketHandler.kt
@@ -28,6 +28,8 @@ public class PacketHandler(private val plugin: JourneyMapBukkit) : PluginMessage
     }
 
     public fun sendWorldId(worldID: String, player: Player) {
+        this.plugin.logger.info("Sending WorldId " + worldID + " to " + player.name)
+
         try {
             this.sendPacket(player, 0.toByte(), worldID.toByteArray(), WORLD_ID_CHANNEL)
         } catch (e: UnsupportedEncodingException) {

--- a/src/main/kotlin/info/journeymap/bukkit/Utils.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/Utils.kt
@@ -1,5 +1,28 @@
 package info.journeymap.bukkit
 
 import org.bukkit.Bukkit
+import org.bukkit.World
 
+/**
+ * @return UID of the primary world
+ */
 public fun getPrimaryWorldId(): String = Bukkit.getWorlds().first().uid.toString()
+
+/**
+ * @return UID of the given world or null if world does not exist
+ * @throws WorldNotFoundException when provided worldName does not correspond to a world
+ */
+public fun getWorldId(worldName: String): String = getWorld(worldName).uid.toString()
+
+/**
+ * @throws WorldNotFoundException when provided worldName does not correspond to a world
+ */
+public fun getWorld(worldName: String): World {
+    val world = Bukkit.getWorlds().find { world -> world.name == worldName }
+
+    if (world !== null) {
+        return world
+    }
+
+    throw WorldNotFoundException(worldName)
+}

--- a/src/main/kotlin/info/journeymap/bukkit/WorldNotFoundException.kt
+++ b/src/main/kotlin/info/journeymap/bukkit/WorldNotFoundException.kt
@@ -1,0 +1,3 @@
+package info.journeymap.bukkit
+
+public class WorldNotFoundException(public val worldName: String) : Exception()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,26 @@
+legacy_configuration_migrated: false
+
+# Whether extra information should be outputted to console (initial configuration print out and when packet sending happens)
+verbose_logging: false
+
+# By default all worlds use the ID of the primary world.
+# That is fine for regular servers with only a "single" world with the three (or less) connected dimensions.
+# If you have a more complicated setup (like a lobby world or some other extra worlds) you will want to
+# configure everything explicitly. Basically you want all worlds that share coordinates (overworld, nether, end)
+# to have the same ID and everything else should be separate. That ensures maps don't get overwritten and
+# features like sharing waypoints between dimensions work.
+worlds:
+#  world:
+#    id_from: world # Use own UID explicitly instead of the "primary" ID as that could be anything
+#  world_nether:
+#    id_from: world # Use UID of the connected overworld
+#  world_the_end:
+#    id_from: world # Use UID of the connected overworld
+#  world_lobby:
+#    id_from: world_lobby # Use own World ID explicitly instead of the "primary" ID as that could be anything
+#  world_legacy:
+#    WorldId: 55874116-2352-4ac6-a291-56b7cd15a877 # Overrides world ID with a custom ID - mainly useful if you had the legacy plugin
+#  world_legacy_nether:
+#    WorldId: 55874116-2352-4ac6-a291-56b7cd15a877 # pair legacy nether with legacy overworld
+#  world_disabled:
+#    UseWorldID: false # Do not send WorldId for this world - you probably don't want to use this if you installed this plugin

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: "JourneyMapBukkit"
-version: "1.1.0"
+version: "1.1.1"
 author: "TeamJM"
 main: "info.journeymap.bukkit.JourneyMapBukkit"
 api-version: "1.18"


### PR DESCRIPTION
- Migrates old plugin configuration (from JourneyMapServer) to standard yaml config.yml on first run
- Allows setting custom world IDs.
- Allows setting world IDs from other worlds.
- Defaults still behave the same (returns primary world ID) for simple servers/setups.
- Configuration should be self-explanatory in the autogenerated/provided yaml.
- Adds option for verbose logging that shows world IDs on startup and enables log message when the packet is being sent.